### PR TITLE
fix server_test TestRawDelete1 cannot be passed

### DIFF
--- a/kv/server/server_test.go
+++ b/kv/server/server_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/Connor1996/badger"
 	"os"
 	"testing"
 
@@ -184,7 +185,7 @@ func TestRawDelete1(t *testing.T) {
 	assert.Nil(t, err)
 
 	val, err := Get(s, cf, []byte{99})
-	assert.Equal(t, nil, err)
+	assert.Equal(t, badger.ErrKeyNotFound, err)
 	assert.Equal(t, []byte(nil), val)
 }
 


### PR DESCRIPTION
kv/server/server_test.go
on test case "TestRawDelete1"
line187: val, err := Get(s, cf, []byte{99})
line188: assert.Equal(t, nil, err)
to
line188: assert.Equal(t, badger.ErrKeyNotFound, err)
Because GetCf try to take a non-existent key,it will return badger.ErrKeyNotFound
So i think its necessary to update its _test.go
ThankYou