### PR TITLE
[kv/util/engine_util] remove dependence on config

### DIFF
--- a/kv/storage/raft_storage/raft_server.go
+++ b/kv/storage/raft_storage/raft_server.go
@@ -68,8 +68,8 @@ func NewRaftStorage(conf *config.Config) *RaftStorage {
 	os.MkdirAll(raftPath, os.ModePerm)
 	os.Mkdir(snapPath, os.ModePerm)
 
-	raftDB := engine_util.CreateDB("raft", conf)
-	kvDB := engine_util.CreateDB("kv", conf)
+	raftDB := engine_util.CreateDB(raftPath, true)
+	kvDB := engine_util.CreateDB(kvPath, false)
 	engines := engine_util.NewEngines(kvDB, raftDB, kvPath, raftPath)
 
 	return &RaftStorage{engines: engines, config: conf}

--- a/kv/test_raftstore/cluster.go
+++ b/kv/test_raftstore/cluster.go
@@ -80,8 +80,8 @@ func (c *Cluster) Start() {
 			panic(err)
 		}
 
-		raftDB := engine_util.CreateDB("raft", c.cfg)
-		kvDB := engine_util.CreateDB("kv", c.cfg)
+		raftDB := engine_util.CreateDB(raftPath, true)
+		kvDB := engine_util.CreateDB(kvPath, false)
 		engine := engine_util.NewEngines(kvDB, raftDB, kvPath, raftPath)
 		c.engines[storeID] = engine
 	}

--- a/kv/util/engine_util/engines.go
+++ b/kv/util/engine_util/engines.go
@@ -2,10 +2,8 @@ package engine_util
 
 import (
 	"os"
-	"path/filepath"
 
 	"github.com/Connor1996/badger"
-	"github.com/pingcap-incubator/tinykv/kv/config"
 	"github.com/pingcap-incubator/tinykv/log"
 )
 
@@ -63,13 +61,13 @@ func (en *Engines) Destroy() error {
 }
 
 // CreateDB creates a new Badger DB on disk at subPath.
-func CreateDB(subPath string, conf *config.Config) *badger.DB {
+func CreateDB(path string, raft bool) *badger.DB {
 	opts := badger.DefaultOptions
-	if subPath == "raft" {
+	if raft {
 		// Do not need to write blob for raft engine because it will be deleted soon.
 		opts.ValueThreshold = 0
 	}
-	opts.Dir = filepath.Join(conf.DBPath, subPath)
+	opts.Dir = path
 	opts.ValueDir = opts.Dir
 	if err := os.MkdirAll(opts.Dir, os.ModePerm); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
> [kv/util/engine_util] remove dependence on config, making the code more concise and efficient.

When using the `CreateDB` function, we get `kvPath` and `raftPath` first just like this:

```go
// Set filepath
dbPath := conf.DBPath
kvPath := filepath.Join(dbPath, "kv")
raftPath := filepath.Join(dbPath, "raft")

// Create database and get engines
raftDB := engine_util.CreateDB("raft", c.cfg)
kvDB := engine_util.CreateDB("kv", c.cfg)
engines := engine_util.NewEngines(kvDB, raftDB, kvPath, raftPath)
```
While in CreateDB, we use `conf.DBPath` repeatedly just like this:

```go
opts.Dir = filepath.Join(conf.DBPath, subPath)
```

Obviously we do the `filepath.Join` twice for both `kv` and `raft`, and the `engine_util` package depends on the `config` package even though all `engine_util` package only needs is a `filepath-conf.DBPath`.

We can fix it by changing the args. of `CreateDB` into `path` string and `raft` bool, which stand for `database directory filepath` and `use raft or not`.

Thanks for your review!
