### PR TITLE
Modify comments of `electionElapsed`

### DIFF
--- a/kv/raftstore/peer_storage_test.go
+++ b/kv/raftstore/peer_storage_test.go
@@ -59,17 +59,17 @@ func newTestEntry(index, term uint64) eraftpb.Entry {
 
 func TestPeerStorageTerm(t *testing.T) {
 	ents := []eraftpb.Entry{
-		newTestEntry(3, 3), newTestEntry(4, 4), newTestEntry(5, 5),
+		newTestEntry(6, 6), newTestEntry(7, 7), newTestEntry(8, 8),
 	}
 	tests := []struct {
 		idx  uint64
 		term uint64
 		err  error
 	}{
-		{2, 0, raft.ErrCompacted},
-		{3, 3, nil},
-		{4, 4, nil},
-		{5, 5, nil},
+		{5, 0, raft.ErrCompacted},
+		{6, 6, nil},
+		{7, 7, nil},
+		{8, 8, nil},
 	}
 	for _, tt := range tests {
 		peerStore := newTestPeerStorageFromEnts(t, ents)

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -138,7 +138,8 @@ type Raft struct {
 	// number of ticks since it reached last heartbeatTimeout.
 	// only leader keeps heartbeatElapsed.
 	heartbeatElapsed int
-	// number of ticks since it reached last electionTimeout
+	// number of ticks since it received last heartbeat.
+	// followers and candidates keeps electionElapsed.
 	electionElapsed int
 
 	// leadTransferee is id of the leader transfer target when its value is not zero.


### PR DESCRIPTION
The comment of this field is difficult to understand, especially for election timeout. This place obviously should not be described as `reached last electionTimeout`. The actual semantics should be the time of the last `received heartbeat`.


```go
// number of ticks since it reached last heartbeatTimeout.
// only leader keeps heartbeatElapsed.
heartbeatElapsed int
// number of ticks since it reached last electionTimeout
electionElapsed int
```
