### PR TITLE
add note for test function acceptAndReply()

### DIFF
--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -916,6 +916,7 @@ func acceptAndReply(m pb.Message) pb.Message {
 	if m.MsgType != pb.MessageType_MsgAppend {
 		panic("type should be MessageType_MsgAppend")
 	}
+	// Note: reply message don't contain LogTerm
 	return pb.Message{
 		From:    m.To,
 		To:      m.From,


### PR DESCRIPTION
The function acceptAndReply() is used to simulate accepte appendEntries and reply. 

I directly use field LogTerm in reply message as the last accepted log term and use it to check for commit when leader get reply. But as LogTerm doesn't init in this function, it cost me a lot of time to fix the bug. 

So I add comment for this function to inform others who might meet same problem.