### PR TITLE
Fix wrong setting in handleStaleMsg function

### DIFF
--- a/kv/raftstore/peer_msg_handler.go
+++ b/kv/raftstore/peer_msg_handler.go
@@ -284,8 +284,8 @@ func handleStaleMsg(trans Transport, msg *rspb.RaftMessage, curEpoch *metapb.Reg
 	}
 	gcMsg := &rspb.RaftMessage{
 		RegionId:    regionID,
-		FromPeer:    fromPeer,
-		ToPeer:      toPeer,
+		FromPeer:    toPeer,
+		ToPeer:      fromPeer,
 		RegionEpoch: curEpoch,
 		IsTombstone: true,
 	}


### PR DESCRIPTION
In the `handleStaleMsg` function, we need to tell the original message sender that it sends a message to a tombstone node. As a reply, `gcMsg`'s `FromPeer` should be `msg.ToPeer` and `ToPeer` should be `msg.FromPeer`. Now the setting is wrong.
