### PR TITLE
modified the description in TestRestoreIgnoreSnapshot2C

### DIFF
--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -996,6 +996,7 @@ func TestRestoreIgnoreSnapshot2C(t *testing.T) {
 	sm := newTestRaft(1, []uint64{1, 2}, 10, 1, storage)
 	sm.RaftLog.committed = 3
 
+	wcommit := uint64(3)
 	commit := uint64(1)
 	s := pb.Snapshot{
 		Metadata: &pb.SnapshotMetadata{
@@ -1007,8 +1008,8 @@ func TestRestoreIgnoreSnapshot2C(t *testing.T) {
 
 	// ignore snapshot
 	sm.handleSnapshot(pb.Message{Snapshot: &s})
-	if sm.RaftLog.committed == commit {
-		t.Errorf("commit = %d, want %d", sm.RaftLog.committed, commit)
+	if sm.RaftLog.committed != wcommit {
+		t.Errorf("commit = %d, want %d", sm.RaftLog.committed, wcommit)
 	}
 }
 


### PR DESCRIPTION
Actually, TestRestoreIgnoreSnapshot2C in raft/raft_test.go wants us to ignore the snapshot, thus `r.RaftLog.committed` should not change. So it is better to say `!=wcommit` instead of `==commit`.  This little problem bothered me for a while at first ^_^