### PR TITLE
Fix TestRecvMessageType_MsgRequestVote2AA

### DIFF
--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -634,7 +634,7 @@ func TestRecvMessageType_MsgRequestVote2AA(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		sm := newTestRaft(1, []uint64{1}, 10, 1, NewMemoryStorage())
+		sm := newTestRaft(1, []uint64{1, 2}, 10, 1, NewMemoryStorage())
 		sm.State = tt.state
 		sm.Vote = tt.voteFor
 		sm.RaftLog = newLog(newMemoryStorageWithEnts([]pb.Entry{{}, {Index: 1, Term: 2}, {Index: 2, Term: 2}}))


### PR DESCRIPTION
Provide valid peers so that messages will not be ignored.

Messages from nodes not in peers should be ignored. This test mocks a response from node 2. So 1 must have a peer named 2.