### PR TITLE
Add test for project2ab

### DIFF
--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -916,6 +916,7 @@ func acceptAndReply(m pb.Message) pb.Message {
 	if m.MsgType != pb.MessageType_MsgAppend {
 		panic("type should be MessageType_MsgAppend")
 	}
+	// Note: reply message don't contain LogTerm
 	return pb.Message{
 		From:    m.To,
 		To:      m.From,


### PR DESCRIPTION
I add a test to check following situation:

There are five nodes 1,2,3,4,5. Assuming that node 5 is isolated from others and raft can keep going. Now, the network recovered and the leader don't receive proposal cmd for a long time, but it will send hearbeart as usual. Since heartbeat response that contains LogIndex indicate follower's LastIndex. The leader should send log to follower when it realize follower doesn't have latest log. 

If raft doesn't achieve this function. It will cause problems in project3 when new node is added to raft. And it may hard to find this bug as it's in 2ab. 

So I add this test to help people to find this bug earlier and  easier.