### PR TITLE
fix an issue in getting GOPATH in generate_go.sh

### DIFF
--- a/proto/generate_go.sh
+++ b/proto/generate_go.sh
@@ -19,11 +19,11 @@ cmd_exists () {
 
 PROGRAM=$(basename "$0")
 
-if [ -z $GOPATH ]; then
+if [ -z $(go env GOPATH) ]; then
     printf "Error: the environment variable GOPATH is not set, please set it before running %s\n" $PROGRAM > /dev/stderr
     exit 1
 fi
-
+GOPATH=$(go env GOPATH)
 GO_PREFIX_PATH=github.com/pingcap-incubator/tinykv/proto/pkg
 export PATH=$(pwd)/_tools/bin:$GOPATH/bin:$PATH
 


### PR DESCRIPTION
In newer version of Go, GOPATH may not be got via `$GOPATH` directly. So, it may be better to get GOPATH via `go env GOPATH`. This little issue bothered me while first running `make proto`.