### PR TITLE
makefile: run 2B and 3B tests one by one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ format:
 	@gofmt -s -w `find . -name '*.go' -type f ! -path '*/_tools/*' -print`
 
 project1:
-	$(GOTEST) ./kv/server -run 1 
+	$(GOTEST) ./kv/server -run 1
 
 project2: project2a project2b project2c
 
@@ -68,7 +68,17 @@ project2ac:
 	$(GOTEST) ./raft -run 2AC
 
 project2b:
-	$(GOTEST) ./kv/test_raftstore -run 2B
+	$(GOTEST) ./kv/test_raftstore -run ^TestBasic2B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestConcurrent2B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestUnreliable2B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestOnePartition2B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestManyPartitionsOneClient2B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestManyPartitionsManyClients2B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestPersistOneClient2B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestPersistConcurrent2B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestPersistConcurrentUnreliable2B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestPersistPartition2B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestPersistPartitionUnreliable2B$ || true
 
 project2c:
 	$(GOTEST) ./raft ./kv/test_raftstore -run 2C
@@ -79,7 +89,21 @@ project3a:
 	$(GOTEST) ./raft -run 3A
 
 project3b:
-	$(GOTEST) ./kv/test_raftstore -run 3B
+	$(GOTEST) ./kv/test_raftstore -run ^TestTransferLeader3B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestBasicConfChange3B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestConfChangeRecover3B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestConfChangeRecoverManyClients3B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestConfChangeUnreliable3B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestConfChangeUnreliableRecover3B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestConfChangeSnapshotUnreliableRecover3B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestConfChangeSnapshotUnreliableRecoverConcurrentPartition3B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestOneSplit3B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestSplitRecover3B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestSplitRecoverManyClients3B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestSplitUnreliable3B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestSplitUnreliableRecover3B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestSplitConfChangeSnapshotUnreliableRecover3B$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestSplitConfChangeSnapshotUnreliableRecoverConcurrentPartition3B$ || true
 
 project3c:
 	$(GOTEST) ./scheduler/server ./scheduler/server/schedulers -check.f="3C"


### PR DESCRIPTION
Signed-off-by: Andy Lok <andylokandy@hotmail.com>

`make project2B` and `make project3B` is likely to fail due to memory leak on `go test`. Testing one by one is one of the workarounds.