### PR TITLE
fix ValidForPrefix wrong arguments order

### DIFF
--- a/kv/util/engine_util/cf_iterator.go
+++ b/kv/util/engine_util/cf_iterator.go
@@ -76,7 +76,7 @@ func (it *BadgerIterator) Item() DBItem {
 func (it *BadgerIterator) Valid() bool { return it.iter.ValidForPrefix([]byte(it.prefix)) }
 
 func (it *BadgerIterator) ValidForPrefix(prefix []byte) bool {
-	return it.iter.ValidForPrefix(append(prefix, []byte(it.prefix)...))
+	return it.iter.ValidForPrefix(append([]byte(it.prefix), prefix...))
 }
 
 func (it *BadgerIterator) Close() {


### PR DESCRIPTION
I think the arguments passed to `badger.Item.ValidForPrefix` is in wrong order in `engine_util.CFItem.ValidForPrefix`. `it.prefix` which represents the *colume family* should be in the front.