### PR TITLE
raft: keep leader term consistent with log entries

### DIFF
--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -635,7 +635,7 @@ func TestFollowerAppendEntries2AB(t *testing.T) {
 			[]*pb.Entry{{Term: 3, Index: 2}, {Term: 4, Index: 3}},
 		},
 		{
-			0, 0, 1,
+			0, 0, 2,
 			[]*pb.Entry{{Term: 1, Index: 1}},
 			[]*pb.Entry{{Term: 1, Index: 1}, {Term: 2, Index: 2}},
 			[]*pb.Entry{},

--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -617,30 +617,31 @@ func TestFollowerCheckMessageType_MsgAppend2AB(t *testing.T) {
 func TestFollowerAppendEntries2AB(t *testing.T) {
 	tests := []struct {
 		index, term uint64
+		lterm       uint64
 		ents        []*pb.Entry
 		wents       []*pb.Entry
 		wunstable   []*pb.Entry
 	}{
 		{
-			2, 2,
+			2, 2, 3,
 			[]*pb.Entry{{Term: 3, Index: 3}},
 			[]*pb.Entry{{Term: 1, Index: 1}, {Term: 2, Index: 2}, {Term: 3, Index: 3}},
 			[]*pb.Entry{{Term: 3, Index: 3}},
 		},
 		{
-			1, 1,
+			1, 1, 4,
 			[]*pb.Entry{{Term: 3, Index: 2}, {Term: 4, Index: 3}},
 			[]*pb.Entry{{Term: 1, Index: 1}, {Term: 3, Index: 2}, {Term: 4, Index: 3}},
 			[]*pb.Entry{{Term: 3, Index: 2}, {Term: 4, Index: 3}},
 		},
 		{
-			0, 0,
+			0, 0, 1,
 			[]*pb.Entry{{Term: 1, Index: 1}},
 			[]*pb.Entry{{Term: 1, Index: 1}, {Term: 2, Index: 2}},
 			[]*pb.Entry{},
 		},
 		{
-			0, 0,
+			0, 0, 3,
 			[]*pb.Entry{{Term: 3, Index: 1}},
 			[]*pb.Entry{{Term: 3, Index: 1}},
 			[]*pb.Entry{{Term: 3, Index: 1}},
@@ -652,7 +653,7 @@ func TestFollowerAppendEntries2AB(t *testing.T) {
 		r := newTestRaft(1, []uint64{1, 2, 3}, 10, 1, storage)
 		r.becomeFollower(2, 2)
 
-		r.Step(pb.Message{From: 2, To: 1, MsgType: pb.MessageType_MsgAppend, Term: 2, LogTerm: tt.term, Index: tt.index, Entries: tt.ents})
+		r.Step(pb.Message{From: 2, To: 1, MsgType: pb.MessageType_MsgAppend, Term: tt.lterm, LogTerm: tt.term, Index: tt.index, Entries: tt.ents})
 
 		wents := make([]pb.Entry, 0, len(tt.wents))
 		for _, ent := range tt.wents {


### PR DESCRIPTION
Signed-off-by: unconsolable <chenzhipeng2012@gmail.com>

close #297 

Problem summary:
- The term of `fake` leader should be as up to date as its log entries.
- However, in this test case, it may just be a minor issue as mainly focusing on log append validation (Section 5.3 in paper).

What is changed & how it works:
- Introduce an additional field `lterm` to indicate leader term
- Set it to be the highest term in log entries.
- Checked on my implementation, seems everything is fine.

