### PR TITLE
fix TestIterWithRawDelete1 test case

### DIFF
--- a/kv/server/server_test.go
+++ b/kv/server/server_test.go
@@ -337,7 +337,7 @@ func TestIterWithRawDelete1(t *testing.T) {
 	_, err = server.RawDelete(nil, delete)
 	assert.Nil(t, err)
 
-	expectedKeys := [][]byte{{1}, {2}, {3}, {4}}
+	expectedKeys := [][]byte{{1}, {2}, {4}}
 	i := 0
 	for it.Seek([]byte{1}); it.Valid(); it.Next() {
 		item := it.Item()


### PR DESCRIPTION
put : [][]byte{{1}, {2}, {3}, {4}}
delete: key([]byte{3})
expect result should be : [][]byte{{1}, {2}, {4}}