### PR TITLE
Fix variable naming

### DIFF
--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -616,11 +616,11 @@ func TestFollowerCheckMessageType_MsgAppend2AB(t *testing.T) {
 // Reference: section 5.3
 func TestFollowerAppendEntries2AB(t *testing.T) {
 	tests := []struct {
-		index, term uint64
-		lterm       uint64
-		ents        []*pb.Entry
-		wents       []*pb.Entry
-		wunstable   []*pb.Entry
+		index, lterm uint64		// prevIndex and prevTerm
+		term         uint64
+		ents         []*pb.Entry
+		wents        []*pb.Entry
+		wunstable    []*pb.Entry
 	}{
 		{
 			2, 2, 3,
@@ -653,7 +653,7 @@ func TestFollowerAppendEntries2AB(t *testing.T) {
 		r := newTestRaft(1, []uint64{1, 2, 3}, 10, 1, storage)
 		r.becomeFollower(2, 2)
 
-		r.Step(pb.Message{From: 2, To: 1, MsgType: pb.MessageType_MsgAppend, Term: tt.lterm, LogTerm: tt.term, Index: tt.index, Entries: tt.ents})
+		r.Step(pb.Message{From: 2, To: 1, MsgType: pb.MessageType_MsgAppend, Term: tt.term, LogTerm: tt.lterm, Index: tt.index, Entries: tt.ents})
 
 		wents := make([]pb.Entry, 0, len(tt.wents))
 		for _, ent := range tt.wents {


### PR DESCRIPTION
Make semantic matching by fixing variable naming. The logic of the function is the same as before without modification.