### PR TITLE
refactor(raft_storage): remove dead code

### DIFF
--- a/kv/storage/raft_storage/raft_server.go
+++ b/kv/storage/raft_storage/raft_server.go
@@ -146,9 +146,6 @@ func (rs *RaftStorage) Reader(ctx *kvrpcpb.Context) (storage.StorageReader, erro
 	if cb.Txn == nil {
 		panic("can not found region snap")
 	}
-	if len(resp.Responses) != 1 {
-		panic("wrong response count for snap cmd")
-	}
 	return NewRegionReader(cb.Txn, *resp.Responses[0].GetSnap().Region), nil
 }
 


### PR DESCRIPTION
Same logic has been checked in `rs.checkResponse(resp, 1)`, therefore line 149-151 are deadcode.