### PR TITLE
chore(Makefile): run Project2C tests separately

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,13 @@ project2b:
 
 project2c:
 	$(TEST_CLEAN)
-	$(GOTEST) ./raft ./kv/test_raftstore -run 2C || true
+	$(GOTEST) ./raft -run 2C || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestOneSnapshot2C$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestSnapshotRecover2C$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestSnapshotRecoverManyClients2C$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestSnapshotUnreliable2C$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestSnapshotUnreliableRecover2C$ || true
+	$(GOTEST) ./kv/test_raftstore -run ^TestSnapshotUnreliableRecoverConcurrentPartition2C$ || true
 	$(TEST_CLEAN)
 
 project3: project3a project3b project3c


### PR DESCRIPTION
We run project tests on CI, each job runs on a machine that has 4 cores CPU 8GB memory, and we realized some project tests only failed in CI environments, such as Project2C. I ran Project2C tests with a memory profiler, each test is only used 4GB of memory at all. In Project2C, we always failed in the second test which is running out of total memory it has.  it looks like the "go test" command didn't GC the memory until all tests are finished.

Related issues: https://github.com/tidb-incubator/tinykv/pull/277

<img width="1718" alt="Screen Shot 2021-12-30 at 18 35 09" src="https://user-images.githubusercontent.com/32535939/147739561-80b92d15-ef15-4d73-8060-e12f8c6bc485.png">

<img width="1407" alt="Screen Shot 2021-12-30 at 18 12 14" src="https://user-images.githubusercontent.com/32535939/147737898-57ae3d91-b9ca-4f91-9323-2aaa3328b213.png">
(running Project2C tests separately, all tests passed)

