### PR TITLE
Fix TestCommitConflictRollback4B

### DIFF
--- a/kv/transaction/commands4b_test.go
+++ b/kv/transaction/commands4b_test.go
@@ -523,7 +523,7 @@ func TestCommitConflictRollback4B(t *testing.T) {
 	})
 	resp := builder.runOneRequest(cmd).(*kvrpcpb.CommitResponse)
 
-	assert.Nil(t, resp.Error)
+	assert.NotNil(t, resp.Error)
 	assert.Nil(t, resp.RegionError)
 	builder.assertLens(0, 0, 1)
 	builder.assert([]kv{


### PR DESCRIPTION
According to the [vldb-2021-labs's](https://github.com/vldbss-2021/vldb-2021-labs/blob/master/tinykv/kv/transaction/commands4b_test.go#L526) code, commit a rollback transaction should report an error, which is more intuitive in my opinion.