### PR TITLE
fix nil pointer dereference in scheduler.go

### DIFF
--- a/kv/test_raftstore/scheduler.go
+++ b/kv/test_raftstore/scheduler.go
@@ -224,6 +224,11 @@ func (m *MockSchedulerClient) AskSplit(ctx context.Context, region *metapb.Regio
 	if err != nil {
 		return resp, err
 	}
+
+	if curRegion == nil || curRegion.GetId() != region.GetId() {
+		return resp, errors.New("region not found")
+	}
+
 	if util.IsEpochStale(region.RegionEpoch, curRegion.RegionEpoch) {
 		return resp, errors.New("epoch is stale")
 	}


### PR DESCRIPTION
I found there may exist a bug when I am doing project3b. Before discussing this problem, we should know that:
When a region `[a, c)` was splitted into two regions `[a, b)` and `[b, c)`, both the new region will send RegionHeartbeat to scheduler to update the region info. When scheduler handle the heartbeat, it will remove the old region `[a, c)` first, and add the new region. Thus it will cause a duration that **there only exist a region**, either `[a, b)` or `[b, c)`. Knowing this, let's discuss further.
Consider there are some regions like:
```txt
["", b), [b, c) ..... [x, z) ....
```
Then region `["", b)` and `[x, z)` were splitted into `["", a)` `[a, b)` and `[x, y)` `[y, z)`. After a while, new region `[a, b)` and `[y, z)` send hearBeat to scheduler, scheduler remove old region `["", b)` and `[x, z)`, and add new region `[a, b)` and `[y, z)`. At this moment, scheduler_task receives a `SchedulerAskSplitTask` which split region `[x, z)`(actually, it was a old task, because former split task has been applied), `MockSchedulerClient.AskSplit` will be called, and continue call `GetRegionByID` which will return nil, thus nil pointer was dereferenced in sentense `if util.IsEpochStale(region.RegionEpoch, curRegion.RegionEpoch)`.

This problem was caused due to the heartbeat message of the second new region reaches to scheduler faster than the first new region.