### PR TITLE
chore: fix string assert in test

### DIFF
--- a/kv/transaction/commands4b_test.go
+++ b/kv/transaction/commands4b_test.go
@@ -541,7 +541,7 @@ func TestCommitConflictRace4B(t *testing.T) {
 	})
 	resp := builder.runOneRequest(cmd).(*kvrpcpb.CommitResponse)
 
-	assert.NotNil(t, resp.Error.Retryable)
+	assert.NotEmpty(t, resp.Error.Retryable)
 	assert.Nil(t, resp.RegionError)
 	builder.assertLens(1, 1, 0)
 	builder.assert([]kv{


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

`assert.NotNil(t, resp.Error.Retryable)` would always be true since `Retryable` is string