### PR TITLE
fix(kv/config): set SchedulerHeartbeatTickInterval to ten seconds

### DIFF
--- a/kv/config/config.go
+++ b/kv/config/config.go
@@ -82,7 +82,7 @@ func NewDefaultConfig() *Config {
 		// Assume the average size of entries is 1k.
 		RaftLogGcCountLimit:                 128000,
 		SplitRegionCheckTickInterval:        10 * time.Second,
-		SchedulerHeartbeatTickInterval:      100 * time.Millisecond,
+		SchedulerHeartbeatTickInterval:      10 * time.Second,
 		SchedulerStoreHeartbeatTickInterval: 10 * time.Second,
 		RegionMaxSize:                       144 * MB,
 		RegionSplitSize:                     96 * MB,


### PR DESCRIPTION
`SchedulerHeartbeatTickInterval` should not be smaller than `RaftBaseTickInterval`, set `SchedulerHeartbeatTickInterval` to ten seconds

fix https://github.com/tidb-incubator/tinykv/issues/393