### PR TITLE
typo in TestLogReplication2AB

### DIFF
--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -264,7 +264,7 @@ func TestLogReplication2AB(t *testing.T) {
 			newNetwork(nil, nil, nil),
 			[]pb.Message{
 				{From: 1, To: 1, MsgType: pb.MessageType_MsgPropose, Entries: []*pb.Entry{{Data: []byte("somedata")}}},
-				{From: 1, To: 2, MsgType: pb.MessageType_MsgHup},
+				{From: 2, To: 2, MsgType: pb.MessageType_MsgHup},
 				{From: 1, To: 2, MsgType: pb.MessageType_MsgPropose, Entries: []*pb.Entry{{Data: []byte("somedata")}}},
 			},
 			4,


### PR DESCRIPTION
According to specification, pb.MessageType_MsgHup is local message, which means it should not be passed from node 1 to node 2. To fit the test, it should be passed from node 2 to node 2.