### PR TITLE
log: make log level case insensitive

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"strings"
 )
 
 const (
@@ -232,6 +233,7 @@ func (l *Logger) Infof(format string, v ...interface{}) {
 }
 
 func StringToLogLevel(level string) LogLevel {
+	level = strings.ToLower(level)
 	switch level {
 	case "fatal":
 		return LOG_LEVEL_FATAL


### PR DESCRIPTION
Signed-off-by: SpadeA-Tang <u6748471@anu.edu.au>
It's better to make log level case insensitive such that LOG_LEVEL = INFO can make effect.