### PR TITLE
ut: add `TestRestoreFromSnapWithOverlapingPeersMsg2C()`

### DIFF
--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -1094,6 +1094,35 @@ func TestRestoreFromSnapMsg2C(t *testing.T) {
 	}
 }
 
+func TestRestoreFromSnapWithOverlapingPeersMsg2C(t *testing.T) {
+	s := pb.Snapshot{
+		Metadata: &pb.SnapshotMetadata{
+			Index:     11, // magic number
+			Term:      11, // magic number
+			ConfState: &pb.ConfState{Nodes: []uint64{2, 3, 4}},
+		},
+	}
+	m := pb.Message{MsgType: pb.MessageType_MsgSnapshot, From: 1, Term: 2, Snapshot: &s}
+
+	sm := newTestRaft(2, []uint64{1, 2, 3}, 10, 1, NewMemoryStorage())
+	sm.Step(m)
+
+	if sm.Lead != uint64(1) {
+		t.Errorf("sm.Lead = %d, want 1", sm.Lead)
+	}
+
+	nodes := s.Metadata.ConfState.Nodes
+	if len(nodes) != len(sm.Prs) {
+		t.Errorf("len(sm.Prs) = %d, want %d", len(sm.Prs), len(nodes))
+	}
+
+	for _, p := range nodes {
+		if _, ok := sm.Prs[p]; !ok {
+			t.Errorf("missing peer %d", p)
+		}
+	}
+}
+
 func TestSlowNodeRestore2C(t *testing.T) {
 	nt := newNetwork(nil, nil, nil)
 	nt.send(pb.Message{From: 1, To: 1, MsgType: pb.MessageType_MsgHup})


### PR DESCRIPTION
Add a unit test `TestRestoreFromSnapWithOverlapingPeersMsg2C()` to check that a snapshot is properly handled. Suppose the  peer set of a raft instance is {1, 2, 3},  then it was required to install snapshot with peer set {2, 3, 4}, some careless coder might forget to delete the stale peer 1, leaving a corrupted peer set.