### PR TITLE
fix 4B testcase

### DIFF
--- a/kv/transaction/commands4b_test.go
+++ b/kv/transaction/commands4b_test.go
@@ -569,9 +569,9 @@ func TestCommitConflictRepeat4B(t *testing.T) {
 	})
 }
 
-// TestCommitMissingPrewrite4a tests committing a transaction which was not prewritten (i.e., a request was lost, but
+// TestCommitMissingPrewrite4B tests committing a transaction which was not prewritten (i.e., a request was lost, but
 // the commit request was not).
-func TestCommitMissingPrewrite4a(t *testing.T) {
+func TestCommitMissingPrewrite4B(t *testing.T) {
 	builder := newBuilder(t)
 	cmd := builder.commitRequest([]byte{3})
 	builder.init([]kv{
@@ -584,7 +584,7 @@ func TestCommitMissingPrewrite4a(t *testing.T) {
 	})
 	resp := builder.runOneRequest(cmd).(*kvrpcpb.CommitResponse)
 
-	assert.Nil(t, resp.Error)
+	assert.NotNil(t, resp.Error)
 	assert.Nil(t, resp.RegionError)
 	builder.assertLens(2, 0, 2)
 	builder.assert([]kv{


### PR DESCRIPTION
committing a transaction which was not prewritten should get an error. 
note this testcase was not used before as it's pattern is 4a (not 4A/4B/4C)