### PR TITLE
add a new interface allEntries to RaftLog

### DIFF
--- a/raft/log.go
+++ b/raft/log.go
@@ -66,6 +66,14 @@ func (l *RaftLog) maybeCompact() {
 	// Your Code Here (2C).
 }
 
+// allEntries return all the entries not compacted.
+// note, exclude any dummy entries from the return value.
+// note, this is one of the test stub functions you need to implement.
+func (l *RaftLog) allEntries() []pb.Entry {
+	// Your Code Here (2A).
+	return nil
+}
+
 // unstableEntries return all the unstable entries
 func (l *RaftLog) unstableEntries() []pb.Entry {
 	// Your Code Here (2A).

--- a/raft/raft_paper_test.go
+++ b/raft/raft_paper_test.go
@@ -659,7 +659,7 @@ func TestFollowerAppendEntries2AB(t *testing.T) {
 		for _, ent := range tt.wents {
 			wents = append(wents, *ent)
 		}
-		if g := r.RaftLog.entries; !reflect.DeepEqual(g, wents) {
+		if g := r.RaftLog.allEntries(); !reflect.DeepEqual(g, wents) {
 			t.Errorf("#%d: ents = %+v, want %+v", i, g, wents)
 		}
 		var wunstable []pb.Entry


### PR DESCRIPTION
Someone, like me, applies the technique that adding a dummy entry at the head of the log to simplify log indexing. Direct accesses on `r.RaftLog.entries` prevents us from applying such a technique. 
Add a new interface `allEntries` on RaftLog may give us more flexibility on implementing RaftLog