### PR TITLE
fix typo

### DIFF
--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -912,8 +912,8 @@ func TestHeartbeatUpdateCommit2AB(t *testing.T) {
 	}
 	for i, tt := range tests {
 		sm1 := newTestRaft(1, []uint64{1, 2, 3}, 10, 1, NewMemoryStorage())
-		sm2 := newTestRaft(1, []uint64{1, 2, 3}, 10, 1, NewMemoryStorage())
-		sm3 := newTestRaft(1, []uint64{1, 2, 3}, 10, 1, NewMemoryStorage())
+		sm2 := newTestRaft(2, []uint64{1, 2, 3}, 10, 1, NewMemoryStorage())
+		sm3 := newTestRaft(3, []uint64{1, 2, 3}, 10, 1, NewMemoryStorage())
 		nt := newNetwork(sm1, sm2, sm3)
 		nt.send(pb.Message{From: 1, To: 1, MsgType: pb.MessageType_MsgHup})
 		nt.isolate(1)


### PR DESCRIPTION
Populate correct id arguments to `newTestRaft` in TestHeartbeatUpdateCommit2AB