### PR TITLE
Update TestProvideSnap2C in raft_test.go

### DIFF
--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -1055,6 +1055,8 @@ func TestProvideSnap2C(t *testing.T) {
 		},
 	}
 	storage := NewMemoryStorage()
+	// explicitly set snapshot index greater than 0, so that IsEmptySnap won't report an empty snap.
+	storage.snapshot.Metadata.Index = 1  // magic number.
 	sm := newTestRaft(1, []uint64{1}, 10, 1, storage)
 	sm.handleSnapshot(pb.Message{Snapshot: &s})
 


### PR DESCRIPTION
`handleSnapshot` only affects states in raft, not affects states in storage. More specifically, the snapshot in memory storage will be as it is after `handleSnapshot`. As a result, when leader is willing to send a snapshot to follower, it is the empty snapshot being sent. 
However, in my implementation, such a sending will be aborted since the snapshot is empty. Therefore, this test fails.
Sending an empty snapshot is definitely shall be rejected, and I update the test case to not confuse ones like me.