### PR TITLE
Update comments for Server.Latches

### DIFF
--- a/kv/server/server.go
+++ b/kv/server/server.go
@@ -19,7 +19,7 @@ var _ tinykvpb.TinyKvServer = new(Server)
 type Server struct {
 	storage storage.Storage
 
-	// (Used in 4A/4B)
+	// (Used in 4B)
 	Latches *latches.Latches
 
 	// coprocessor API handler, out of course scope


### PR DESCRIPTION
Project4A does not need `Server.Latches`.