### PR TITLE
Fix the update timing of LastCompactedIdx

### DIFF
--- a/kv/raftstore/peer.go
+++ b/kv/raftstore/peer.go
@@ -85,10 +85,6 @@ type peer struct {
 	// (Used in 2B)
 	proposals []*proposal
 
-	// Index of last scheduled compacted raft log.
-	// (Used in 2C)
-	LastCompactedIdx uint64
-
 	// Cache the peers information from other stores
 	// when sending raft messages to other peers, it's used to get the store id of target peer
 	// (Used in 3B conf change)

--- a/kv/raftstore/peer_msg_handler.go
+++ b/kv/raftstore/peer_msg_handler.go
@@ -154,10 +154,8 @@ func (d *peerMsgHandler) ScheduleCompactLog(truncatedIndex uint64) {
 	raftLogGCTask := &runner.RaftLogGCTask{
 		RaftEngine: d.ctx.engine.Raft,
 		RegionID:   d.regionId,
-		StartIdx:   d.LastCompactedIdx,
 		EndIdx:     truncatedIndex + 1,
 	}
-	d.LastCompactedIdx = raftLogGCTask.EndIdx
 	d.ctx.raftLogGCTaskSender <- raftLogGCTask
 }
 

--- a/kv/raftstore/runner/runner_test.go
+++ b/kv/raftstore/runner/runner_test.go
@@ -135,7 +135,6 @@ func TestGcRaftLog(t *testing.T) {
 			raftLogGcTask: &RaftLogGCTask{
 				RaftEngine: raftDb,
 				RegionID:   regionId,
-				StartIdx:   uint64(0),
 				EndIdx:     uint64(10),
 			},
 			expectedCollected: uint64(10),
@@ -147,7 +146,6 @@ func TestGcRaftLog(t *testing.T) {
 			raftLogGcTask: &RaftLogGCTask{
 				RaftEngine: raftDb,
 				RegionID:   regionId,
-				StartIdx:   uint64(0),
 				EndIdx:     uint64(50),
 			},
 			expectedCollected: uint64(40),
@@ -159,7 +157,6 @@ func TestGcRaftLog(t *testing.T) {
 			raftLogGcTask: &RaftLogGCTask{
 				RaftEngine: raftDb,
 				RegionID:   regionId,
-				StartIdx:   uint64(50),
 				EndIdx:     uint64(50),
 			},
 			expectedCollected: uint64(0),
@@ -171,7 +168,6 @@ func TestGcRaftLog(t *testing.T) {
 			raftLogGcTask: &RaftLogGCTask{
 				RaftEngine: raftDb,
 				RegionID:   regionId,
-				StartIdx:   uint64(50),
 				EndIdx:     uint64(60),
 			},
 			expectedCollected: uint64(10),


### PR DESCRIPTION
This PR is to solve the problem mentioned in #440 . After the modification, raftLogGCWorker is responsible for the update of LastCompletedIdx, which is more secure.