### PR TITLE
fix(to issue#455): fix a typo

### DIFF
--- a/kv/raftstore/peer.go
+++ b/kv/raftstore/peer.go
@@ -209,7 +209,7 @@ func (p *peer) Destroy(engine *engine_util.Engines, keepData bool) error {
 		return err
 	}
 	meta.WriteRegionState(kvWB, region, rspb.PeerState_Tombstone)
-	// write kv rocksdb first in case of restart happen between two write
+	// write kv badgerDB first in case of restart happen between two write
 	if err := kvWB.WriteToDB(engine.Kv); err != nil {
 		return err
 	}


### PR DESCRIPTION
I am recently debugging at 3B. And when I am reading the Destroy function at file kv/raftstore/peer.go, I found that there is a comment "write kv rocksdb first in case of restart happen between two write". The previous lab in tinykv seems never mention about rocksdb, while the TiKV mentioned. So I think there is a typo, and this comment should be modified to "write kv badgerDB first in case of restart happen between two write".