### PR TITLE
Correct the test case to prevent it from not being tested.

### DIFF
--- a/kv/transaction/commands4b_test.go
+++ b/kv/transaction/commands4b_test.go
@@ -569,9 +569,9 @@ func TestCommitConflictRepeat4B(t *testing.T) {
 	})
 }
 
-// TestCommitMissingPrewrite4a tests committing a transaction which was not prewritten (i.e., a request was lost, but
+// TestCommitMissingPrewrite4B tests committing a transaction which was not prewritten (i.e., a request was lost, but
 // the commit request was not).
-func TestCommitMissingPrewrite4a(t *testing.T) {
+func TestCommitMissingPrewrite4B(t *testing.T) {
 	builder := newBuilder(t)
 	cmd := builder.commitRequest([]byte{3})
 	builder.init([]kv{


### PR DESCRIPTION
When I tested project4B (make project4B), TestCommitMissingPrewrite was not executed, but in fact, it is a very good test case to find the bug.